### PR TITLE
Docker & Herokuで動かすための編集

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,35 @@
-FROM golang:onbuild
+FROM ubuntu:16.04
 
-COPY ./main.go ./main.go
+# docker build ./ -t spajam
+# docker run --name hogehoge -d -p 3000:3000 spajam
 
-CMD ["go", "run", "main.go"]
+# apt-get
+RUN apt-get update -y && apt-get install -y \
+golang \
+git
+
+# env setting
+ENV HOME /root
+ENV GOPATH $HOME/go
+
+# go get
+RUN go get golang.org/x/net/websocket
+
+# source get
+RUN mkdir /spajam2018_server
+COPY ./api.go /spajam2018_server/
+COPY ./enc.sh /spajam2018_server/
+COPY ./fireUtils.go /spajam2018_server/
+COPY ./main.go /spajam2018_server/
+COPY ./temp.go /spajam2018_server/
+
+# build
+WORKDIR /spajam2018_server
+RUN go build
+RUN chmod 777 enc.sh
+
+# Install FFMPEG
+RUN apt update
+RUN apt install ffmpeg libav-tools x264 x265 -y
+
+CMD ["/spajam2018_server/spajam2018_server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:onbuild
+
+COPY ./main.go ./main.go
+
+CMD ["go", "run", "main.go"]

--- a/fireUtils.go
+++ b/fireUtils.go
@@ -48,7 +48,7 @@ func ConvertM4aToWav() (error) {
 }
 
 
-func CreateResponse(empathResponse EmpathResponse) MirrorBowlResponse {
+func CreateResponse(empathResponse EmpathResponse) MirrorBallResponse {
 
 	// 統計処理
 	Tension[0] = Tension[1]
@@ -62,7 +62,7 @@ func CreateResponse(empathResponse EmpathResponse) MirrorBowlResponse {
 
 		// APIエラーがある場合
 		if empathResponse.Error != 0 {
-			return MirrorBowlResponse{
+			return MirrorBallResponse{
 				Suggestion: "9",
 				Tention:0,
 				Emotion: Emotion{
@@ -114,7 +114,7 @@ func CreateResponse(empathResponse EmpathResponse) MirrorBowlResponse {
 				resSuggestion = checkSuggestion[0]
 			}
 
-			return MirrorBowlResponse{
+			return MirrorBallResponse{
 				Suggestion: resSuggestion,
 				Tention: resTension,
 				Emotion: Emotion{
@@ -128,7 +128,7 @@ func CreateResponse(empathResponse EmpathResponse) MirrorBowlResponse {
 		}
 	} else {
 		// 評価回数じゃない場合
-		return MirrorBowlResponse{
+		return MirrorBallResponse{
 			Suggestion: "",
 			Tention: empathResponse.Energy,
 			Emotion: Emotion{

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ type Emotion struct {
 	Energy int `json:"energy"`
 }
 
-type MirrorBowlResponse struct {
+type MirrorBallResponse struct {
 	Suggestion string  `json:"suggestion"`
 	Tention    int     `json:"tention"`
 	Emotion    Emotion `json:"emotion"`
@@ -34,7 +34,7 @@ type MirrorBowlResponse struct {
 func main() {
 	fmt.Println("Run Server")
 
-	http.Handle("/mirror_bowl", websocket.Handler(MirrorBowlHandler))
+	http.Handle("/mirror_ball", websocket.Handler(MirrorBallHandler))
 	http.Handle("/echo", websocket.Handler(EchoHandler))
 	port := os.Getenv("PORT")
 	if len(port) == 0 {
@@ -46,7 +46,7 @@ func main() {
 	}
 }
 
-func MirrorBowlHandler(ws *websocket.Conn) {
+func MirrorBallHandler(ws *websocket.Conn) {
 	var err error
 	for {
 		var v Voice

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"io"
 	"golang.org/x/net/websocket"
 	"net/http"
@@ -35,7 +36,11 @@ func main() {
 
 	http.Handle("/mirror_bowl", websocket.Handler(MirrorBowlHandler))
 	http.Handle("/echo", websocket.Handler(EchoHandler))
-	err := http.ListenAndServe(":3000", nil)
+	port := os.Getenv("PORT")
+	if len(port) == 0 {
+		port = "3000"
+	}
+	err := http.ListenAndServe(":" + port, nil)
 	if err != nil {
 		panic("ListenAndServe: " + err.Error())
 	}


### PR DESCRIPTION
## Herokuへのデプロイ方法について

公式の Deploy タブの Container Registry を見ていただければ大体書いてあります。

下記リンクも読みやすいかと思います。  
わからないところあればなんでも聞いてください。

https://qiita.com/sho7650/items/9654377a8fc2d4db236d

- 「デプロイの流れとコマンド」について補足
    - 5は `heroku container:push --app mirror-ball web` のようにアプリ名の指定が必要かも
    - 最近の変更で上記の後に `heroku container:release web` のコマンドが必要になりました
    - Webサイトではないので 7 の `heroku open` は不要です

heroku/masterにプッシュしても動かすことはできるはずです。  
あんまり頑張ってないながらちょっと試してもうまくいかなかったので  
断念しましたが、できるならそっちの方が良いかと思われます。  
(デプロイ済みのコード = masterのソースコード と明示的になるため)

## 変更ファイル

### Dockerfile

参考にいただいたDockerfileから以下の点を修正しました。

- ソースコードは `git clone` ではなく `COPY` で取得
    - `git clone` だとGithub上にあるものでしか動かせないため
    - ディレクトリにまとめてコピーしたいところですが、まとめたら  
goのビルド周りがうまくいかなかったので泣く泣くこうしました
- `EXPOSE 3000` の削除
    - ポートはherokuが決めるので(且つ EXPOSEはherokuが未サポートなので)
- アプリ起動コマンドの変更
    - `ENTRYPOINT` ではなく `CMD` 使え的なエラーが出たため `CMD` に変更
    - 手元のLinterで配列型で値指定しろと言われたのでその通り変更

### heroku.yml

herokuの設定ファイルです。  
どこのDockerfileを使うか書いてあります。

### main.go

前述しましたが、HerokuではHerokuがポート番号を指定します。  
Heroku指定のポート番号は環境変数 `PORT` に格納されているため、  
これを利用します。

外から叩くときはポート番号は意識せず https や今回の場合は wss でURL指定すればあたりに行けます。

## 補足

ffmpeg のインストールを考慮しなければ、  
1コミット目のDockerfileで動いていました。

1コミット目の方がgoのイメージを利用したよりシンプルな  
Dockerfileかと思うので、可能であればに近づけられたらと思います。  
(が、ffmpegのインストールができず挫折しました)

resolve #2